### PR TITLE
Update PhysicalButton.swift

### DIFF
--- a/PhysicalButton.swift
+++ b/PhysicalButton.swift
@@ -54,6 +54,7 @@ class PhysicalButton: CustomDebugStringConvertible {
                 } else {
                     // This is supported by Swift:
                     isInUse = false
+                    volumeButtonHandler = nil 
                 }
             }
         }


### PR DESCRIPTION
set volumeButtonHandler to nil when user set isInUse to false, to prevent volumeButtonHandler work when camera view controller are dismiss